### PR TITLE
Handle last GIF when optimize has no URL

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -8,7 +8,8 @@
 ```
 
 ### Optimizing an attached GIF
-Upload a GIF file to Discord and add the command as the comment:
+Upload a GIF file to Discord and add the command as the comment or in a
+separate message right after:
 ```
 <p>optimize
 ```

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The script is designed to be used with Nighty Selfbot. Here are the main command
   Optimize a GIF from a URL with optional parameters
 
 - `<p>optimize [--lossy=<value>] [--speed=<factor>]`
-  Optimize an attached GIF file with optional parameters
+  Optimize an attached GIF or the GIF from the previous message
 
 - `<p>optimize setup`
   Show Docker setup instructions


### PR DESCRIPTION
## Summary
- support fetching a GIF from the previous message when no URL or attachment is provided
- document the new behaviour in README and examples
- fix missing `except` block so the script compiles

## Testing
- `python -m py_compile script/gif_optimizer.py`

------
https://chatgpt.com/codex/tasks/task_e_6846dc6aeae883208104de4ac2112c4a